### PR TITLE
Fix UnicodeDecodeError for ads with non-ascii chars

### DIFF
--- a/googleads/adwords.py
+++ b/googleads/adwords.py
@@ -812,7 +812,7 @@ class BatchJobHelper(object):
       Raises:
         AttributeError: if the provided XML isn't from AdWords.
       """
-      root = ElementTree.fromstring(raw_request_xml.encode('utf-8'))
+      root = ElementTree.fromstring(raw_request_xml)
       return root.find('{http://schemas.xmlsoap.org/soap/envelope/}Body').find(
           './/')
 


### PR DESCRIPTION
Don't encode a bytestring twice. This will throw a UnicodeDecodeError on strings with non-ascii chars, since Python will then try to first decode the bytestring using the 'ascii' encoding, which will fail.
